### PR TITLE
Fix: Correct file path in cp command

### DIFF
--- a/install-x86.sh
+++ b/install-x86.sh
@@ -690,7 +690,7 @@ x86-fix-3.256() {
   #mv hw.py.1 hw.py
   cp -f ${APP_PATH}/patches/hw.py hw.py
 
-  cp -f ${APP_PATH}patches/main.yaml /etc/kvmd/
+  cp -f ${APP_PATH}/patches/main.yaml /etc/kvmd/
 
 } # end x86-fix-3.256
 


### PR DESCRIPTION
脚本中的 cp 命令缺少 ${APP_PATH} 和 patches/main.yaml 之间的斜杠,添加缺失的斜杠以确保文件路径正确.