### PR TITLE
fix: 修复由于非法的 HTML 标签造成的宏中脚本事件个数信息位置错误的问题

### DIFF
--- a/web/kvm/index.html
+++ b/web/kvm/index.html
@@ -781,7 +781,7 @@
             </tr>
             <tr>
               <td i18n="macro_script_events">Scripted events:</td>
-              <tdvalue id="hid-recorder-events-count">0</tdvalue>
+              <td id="hid-recorder-events-count">0</td>
               <td><sup><i i18n="macro_include_delays">include delays</i></sup></td>
             </tr>
           </table>


### PR DESCRIPTION
<img width="344" height="215" alt="image" src="https://github.com/user-attachments/assets/19edcced-120f-4768-93e1-f44a96e75546" />
