### PR TITLE
fix: 修复 WebRTC 音频/视频接收器重启时破音问题

### DIFF
--- a/src/webrtc/universal_session.rs
+++ b/src/webrtc/universal_session.rs
@@ -674,7 +674,13 @@ impl UniversalSession {
             );
         });
 
-        *self.video_receiver_handle.lock().await = Some(handle);
+        {
+            let mut guard = self.video_receiver_handle.lock().await;
+            if let Some(old) = guard.take() {
+                old.abort();
+            }
+            *guard = Some(handle);
+        }
     }
 
     pub async fn start_audio_from_opus(
@@ -761,7 +767,13 @@ impl UniversalSession {
             );
         });
 
-        *self.audio_receiver_handle.lock().await = Some(handle);
+        {
+            let mut guard = self.audio_receiver_handle.lock().await;
+            if let Some(old) = guard.take() {
+                old.abort();
+            }
+            *guard = Some(handle);
+        }
     }
 
     pub fn has_audio(&self) -> bool {


### PR DESCRIPTION
start_audio_from_opus 和 start_from_video_frames 替换旧 handle 时先 abort 旧任务，防止新旧两个任务同时向同一个 track 写数据导致破音。