### PR TITLE
fix: 关闭 MSD 后保存 HID 配置时端点预算校验误判超限

### DIFF
--- a/web/src/views/SettingsView.vue
+++ b/web/src/views/SettingsView.vue
@@ -1129,10 +1129,10 @@ async function saveConfig() {
         hidUpdate.otg_functions = { ...config.value.hid_otg_functions }
         hidUpdate.otg_keyboard_leds = config.value.hid_otg_keyboard_leds
       }
-      await configStore.updateHid(hidUpdate)
       await configStore.updateMsd({
         enabled: config.value.msd_enabled,
       })
+      await configStore.updateHid(hidUpdate)
     }
 
     if (activeSection.value === 'msd') {


### PR DESCRIPTION
## Summary

调换 `saveConfig` 中 `updateMsd` 和 `updateHid` 的调用顺序，确保 HID 校验端点预算时 MSD 状态已更新。

Closes #260