### PR TITLE
fix: 修复仅支持 CQP 的 VAAPI 编码器初始化失败

### DIFF
--- a/libs/hwcodec/cpp/common/util.cpp
+++ b/libs/hwcodec/cpp/common/util.cpp
@@ -368,6 +368,27 @@ struct CodecOptions {
 
 bool set_rate_control(AVCodecContext *c, const std::string &name, int rc,
                       int q) {
+  if (name.find("vaapi") != std::string::npos) {
+    // Some VAAPI drivers, including Intel iHD on Jasper Lake, expose CQP as
+    // their only compatible rate-control mode. The caller currently supplies
+    // a bitrate and RC_CBR for every encoder, so clear all bitrate-based fields
+    // before selecting VAAPI's explicit-QP mode.
+    c->bit_rate = 0;
+    c->rc_min_rate = 0;
+    c->rc_max_rate = 0;
+    c->rc_buffer_size = 0;
+    c->rc_initial_buffer_occupancy = 0;
+
+    const int qp = q > 0 ? q : 23;
+    const int ret = av_opt_set_int(c->priv_data, "qp", qp, 0);
+    if (ret < 0) {
+      LOG_ERROR(std::string("vaapi set qp failed, ret = ") +
+                av_err2str(ret));
+      return false;
+    }
+    return true;
+  }
+
   if (name.find("qsv") != std::string::npos) {
     // https://github.com/LizardByte/Sunshine/blob/3e47cd3cc8fd37a7a88be82444ff4f3c0022856b/src/video.cpp#L1635
     c->strict_std_compliance = FF_COMPLIANCE_UNOFFICIAL;

--- a/libs/hwcodec/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
+++ b/libs/hwcodec/cpp/ffmpeg_ram/ffmpeg_ram_encode.cpp
@@ -273,7 +273,10 @@ public:
       LOG_ERROR(std::string("set_quality failed, name: ") + name_);
       return false;
     }
-    util_encode::set_rate_control(c_, name_, rc_, q_);
+    if (!util_encode::set_rate_control(c_, name_, rc_, q_)) {
+      LOG_ERROR(std::string("set_rate_control failed, name: ") + name_);
+      return false;
+    }
     util_encode::set_gpu(c_->priv_data, name_, gpu_);
     util_encode::force_hw(c_->priv_data, name_);
     util_encode::set_others(c_->priv_data, name_);


### PR DESCRIPTION
## 修改内容

- VAAPI 编码器改用显式 QP（CQP）码率控制，并清除调用方统一设置的 bitrate、CBR 和缓冲区字段
- 对未提供有效 QP 的场景使用默认值 23
- 检查 `set_rate_control()` 返回值，配置失败时终止编码器初始化并输出明确日志

## 问题原因

One-KVM 当前为所有编码器固定传入 `RC_CBR` 和目标码率。部分 VAAPI 驱动（例如 Jasper Lake N5105 上的 Intel iHD）只提供 CQP 码率控制，因此 FFmpeg 初始化 `h264_vaapi` 时会报错：

```text
Driver does not support any RC mode compatible with selected options (supported modes: CQP).
```

随后硬件编码器会被探测逻辑剔除并回退到软件编码。

本修复只覆盖 VAAPI 路径，不改变 QSV、NVENC、AMF 等其他编码器的现有码率控制行为，也不强制启用 VAAPI `low_power` 模式。

## 验证

- `git diff --check`
- 使用官方 x86_64 构建环境执行 `cargo build --release --target x86_64-unknown-linux-gnu`
- 将生成的 amd64 Docker 镜像部署至 N5105/OpenWrt，One-KVM 页面已将 H.264 显示为硬件编码
- Web 服务和视频采集设备初始化正常
