### PR TITLE
feat: UAC USB 麦克风透传

### DIFF
--- a/src/audio/uac_streamer.rs
+++ b/src/audio/uac_streamer.rs
@@ -8,7 +8,7 @@ use tracing::{info, warn};
 use crate::error::{AppError, Result};
 
 /// Kill aplay after this much idle time (no incoming audio frames).
-const IDLE_CLOSE_TIMEOUT_MS: u64 = 2000;
+const IDLE_CLOSE_TIMEOUT_MS: u64 = 5000;
 
 /// Configuration for the UAC playback stream.
 #[derive(Debug, Clone)]
@@ -82,10 +82,12 @@ impl UacPlaybackWriter {
             .arg("-f").arg("S16_LE")
             .arg("-r").arg(rate.to_string())
             .arg("-c").arg(ch.to_string())
+            .arg("--buffer-size=32768")       // ~680ms buffer, tolerant to jitter
+            .arg("--period-size=1024")
             .arg("-")                         // stdin
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
-            .stderr(Stdio::inherit());        // → journalctl
+            .stderr(Stdio::null());           // suppress underrun noise
 
         match cmd.spawn() {
             Ok(mut child) => {
@@ -115,6 +117,7 @@ impl UacPlaybackWriter {
         let idle_timeout = Duration::from_millis(IDLE_CLOSE_TIMEOUT_MS);
         let mut aplay: Option<(Child, Box<dyn Write + Send>)> = None;
         let mut last_write = std::time::Instant::now();
+        let mut was_idle = false;
         let mut frame_count: u64 = 0;
         let mut byte_count: u64 = 0;
 
@@ -150,6 +153,14 @@ impl UacPlaybackWriter {
             match frame {
                 Some(f) => {
                     last_write = std::time::Instant::now();
+
+                    // If resuming after idle, force a fresh aplay
+                    if was_idle {
+                        if let Some((c, s)) = aplay.take() {
+                            Self::kill_aplay(c, s);
+                        }
+                        was_idle = false;
+                    }
 
                     // Ensure aplay is alive
                     if aplay.is_none() {
@@ -195,6 +206,7 @@ impl UacPlaybackWriter {
                     if let Some((c, s)) = aplay.take() {
                         Self::kill_aplay(c, s);
                     }
+                    was_idle = true;
                     if *stop_rx.borrow() {
                         break;
                     }


### PR DESCRIPTION
浏览器麦克风 → Opus(WebCodecs 64kbps) → WebSocket → one-kvm → aplay → UAC1 Gadget → Windows USB 麦克风

## 数据流
浏览器 getUserMedia() → AudioEncoder(Opus 64kbps) → WebSocket → one-kvm → audiopus 解码 → PCM → aplay 子进程 → UAC1 Gadget (ConfigFS) → DWC3 USB → Windows USB 麦克风

## 带宽优化
Raw PCM (48kHz stereo S16LE) ~1.5 Mbps → Opus 64kbps ~16 kbps (100× 缩减)

## 新增文件
- src/otg/uac.rs — UAC1 ConfigFS gadget
- src/audio/uac_streamer.rs — aplay 子进程 PCM 播放
- src/audio/uac_websocket.rs — WebSocket Opus/PCM 接收
- src/web/uac_ws.rs — /api/ws/uac-audio 端点
- src/web/handlers/config/uac.rs — UAC 配置 API
- web/src/composables/useMicrophone.ts — 浏览器麦克风+Opus 编码

## 关键修复
- DWC3 复合设备等时端点: c_chmask=0 + req_number=4 + UAC 优先创建
- aplay 欠载恢复: 空闲后强杀旧进程, buffer-size=32768

## UI
- 设置页 UAC 开关
- 操作栏麦克风按钮(UAC 未开自动隐藏)