### PR TITLE
fix: UAC aplay 欠载恢复 + 大缓冲

### DIFF
--- a/src/audio/uac_streamer.rs
+++ b/src/audio/uac_streamer.rs
@@ -8,7 +8,7 @@ use tracing::{info, warn};
 use crate::error::{AppError, Result};
 
 /// Kill aplay after this much idle time (no incoming audio frames).
-const IDLE_CLOSE_TIMEOUT_MS: u64 = 2000;
+const IDLE_CLOSE_TIMEOUT_MS: u64 = 5000;
 
 /// Configuration for the UAC playback stream.
 #[derive(Debug, Clone)]
@@ -82,10 +82,12 @@ impl UacPlaybackWriter {
             .arg("-f").arg("S16_LE")
             .arg("-r").arg(rate.to_string())
             .arg("-c").arg(ch.to_string())
+            .arg("--buffer-size=32768")       // ~680ms buffer, tolerant to jitter
+            .arg("--period-size=1024")
             .arg("-")                         // stdin
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
-            .stderr(Stdio::inherit());        // → journalctl
+            .stderr(Stdio::null());           // suppress underrun noise
 
         match cmd.spawn() {
             Ok(mut child) => {
@@ -115,6 +117,7 @@ impl UacPlaybackWriter {
         let idle_timeout = Duration::from_millis(IDLE_CLOSE_TIMEOUT_MS);
         let mut aplay: Option<(Child, Box<dyn Write + Send>)> = None;
         let mut last_write = std::time::Instant::now();
+        let mut was_idle = false;
         let mut frame_count: u64 = 0;
         let mut byte_count: u64 = 0;
 
@@ -150,6 +153,14 @@ impl UacPlaybackWriter {
             match frame {
                 Some(f) => {
                     last_write = std::time::Instant::now();
+
+                    // If resuming after idle, force a fresh aplay
+                    if was_idle {
+                        if let Some((c, s)) = aplay.take() {
+                            Self::kill_aplay(c, s);
+                        }
+                        was_idle = false;
+                    }
 
                     // Ensure aplay is alive
                     if aplay.is_none() {
@@ -195,6 +206,7 @@ impl UacPlaybackWriter {
                     if let Some((c, s)) = aplay.take() {
                         Self::kill_aplay(c, s);
                     }
+                    was_idle = true;
                     if *stop_rx.borrow() {
                         break;
                     }


### PR DESCRIPTION
UAC USB 麦克风透传功能已在 **PR #282** 合并。此 PR 为补充修复。

## 修复内容

1. 空闲后重新连接时强杀旧 aplay — 避免复用时处于欠载坏状态导致无声音
2. aplay buffer-size 16384 → 32768 — 680ms 缓冲，容忍 WebSocket/Opus 编码抖动
3. aplay stderr → /dev/null — 抑制持续欠载警告刷屏
4. 空闲超时 2s → 5s — 更宽容语音停顿

## 变动

单文件 src/audio/uac_streamer.rs
