### PR TITLE
fix: 修复 UAC 麦克风透传在 DWC3 上的播放失败

### DIFF
--- a/src/audio/uac/playback.rs
+++ b/src/audio/uac/playback.rs
@@ -1,18 +1,16 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::io::Write;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use alsa::pcm::{Access, Format, Frames, HwParams, State};
-use alsa::{Direction, ValueOr, PCM};
+use tokio::sync::mpsc;
 use tracing::{info, warn};
 
 use crate::error::{AppError, Result};
 
-const RETRY_BACKOFF: Duration = Duration::from_secs(1);
-const PERIOD_FRAMES: Frames = 960;
-const BUFFER_FRAMES: Frames = 4_800;
-const START_THRESHOLD_PERIODS: Frames = 4;
-const SINK_STALL_TIMEOUT: Duration = Duration::from_millis(200);
+const IDLE_CLOSE_TIMEOUT: Duration = Duration::from_secs(5);
+const APLAY_QUEUE_DEPTH: usize = 64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UacPlaybackState {
@@ -29,6 +27,24 @@ impl UacPlaybackState {
             Self::Waiting => "waiting",
             Self::Active => "active",
             Self::Stalled => "stalled",
+        }
+    }
+
+    fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Idle,
+            1 => Self::Waiting,
+            2 => Self::Active,
+            _ => Self::Stalled,
+        }
+    }
+
+    fn to_u8(self) -> u8 {
+        match self {
+            Self::Idle => 0,
+            Self::Waiting => 1,
+            Self::Active => 2,
+            Self::Stalled => 3,
         }
     }
 }
@@ -54,55 +70,11 @@ impl Default for UacPlaybackConfig {
 struct PlaybackInner {
     config: UacPlaybackConfig,
     stopped: AtomicBool,
-    active_session: Mutex<Option<Arc<Mutex<SessionRuntime>>>>,
+    active_session: Mutex<Option<Arc<SessionShared>>>,
 }
 
-enum SessionSink {
-    Closed { retry_at: Option<Instant> },
-    Probing { pcm: PCM, stalled: bool },
-    Active { pcm: PCM, last_progress: Instant },
-}
-
-impl SessionSink {
-    fn state(&self) -> UacPlaybackState {
-        match self {
-            Self::Closed { retry_at: None } => UacPlaybackState::Waiting,
-            Self::Closed { retry_at: Some(_) } => UacPlaybackState::Stalled,
-            Self::Probing { stalled: false, .. } => UacPlaybackState::Waiting,
-            Self::Probing { stalled: true, .. } => UacPlaybackState::Stalled,
-            Self::Active { .. } => UacPlaybackState::Active,
-        }
-    }
-}
-
-struct SessionRuntime {
-    sink: SessionSink,
-}
-
-impl SessionRuntime {
-    fn new() -> Self {
-        Self {
-            sink: SessionSink::Closed { retry_at: None },
-        }
-    }
-
-    fn state(&self) -> UacPlaybackState {
-        self.sink.state()
-    }
-
-    fn close(&mut self) {
-        self.sink = SessionSink::Closed { retry_at: None };
-    }
-
-    /// Advance playback only when a WebSocket frame arrives. All ALSA handles
-    /// are non-blocking, so a slow or absent USB host drops the current frame
-    /// instead of occupying a worker thread or accumulating stale speech.
-    fn write(&mut self, config: &UacPlaybackConfig, samples: &[i16]) -> bool {
-        let sink = std::mem::replace(&mut self.sink, SessionSink::Closed { retry_at: None });
-        let (next_sink, accepted) = drive_sink(sink, config, samples);
-        self.sink = next_sink;
-        accepted
-    }
+struct SessionShared {
+    state: AtomicU8,
 }
 
 #[derive(Clone)]
@@ -112,7 +84,8 @@ pub struct UacPlayback {
 
 pub struct UacSession {
     playback: UacPlayback,
-    runtime: Arc<Mutex<SessionRuntime>>,
+    tx: mpsc::Sender<Vec<u8>>,
+    shared: Arc<SessionShared>,
 }
 
 impl UacPlayback {
@@ -145,55 +118,65 @@ impl UacPlayback {
             ));
         }
 
-        let runtime = Arc::new(Mutex::new(SessionRuntime::new()));
-        *active = Some(Arc::clone(&runtime));
+        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(APLAY_QUEUE_DEPTH);
+        let shared = Arc::new(SessionShared {
+            state: AtomicU8::new(UacPlaybackState::Waiting.to_u8()),
+        });
+        *active = Some(Arc::clone(&shared));
+        drop(active);
+
+        let config = self.inner.config.clone();
+        let thread_state = Arc::clone(&shared);
+        std::thread::Builder::new()
+            .name("uac-aplay".into())
+            .spawn(move || {
+                aplay_loop(&config, &mut rx, &thread_state);
+            })
+            .map_err(|e| AppError::Internal(format!("Failed to spawn UAC playback thread: {e}")))?;
+
         Ok(UacSession {
             playback: self.clone(),
-            runtime,
+            tx,
+            shared,
         })
     }
 
-    /// Stop accepting frames and synchronously close an active ALSA handle.
-    /// This guarantees configfs may rebuild the UAC function after this call.
     pub fn stop(&self) {
         if self.inner.stopped.swap(true, Ordering::AcqRel) {
             return;
         }
-        let runtime = self.inner.active_session.lock().unwrap().take();
-        if let Some(runtime) = runtime {
-            runtime.lock().unwrap().close();
+        if let Some(shared) = self.inner.active_session.lock().unwrap().take() {
+            shared
+                .state
+                .store(UacPlaybackState::Idle.to_u8(), Ordering::Release);
         }
     }
 }
 
 impl UacSession {
     pub fn state(&self) -> UacPlaybackState {
-        self.runtime.lock().unwrap().state()
+        UacPlaybackState::from_u8(self.shared.state.load(Ordering::Acquire))
     }
 
-    /// Returns whether the frame was accepted and the resulting target state.
+    /// Returns whether the frame was accepted and the resulting state.
     pub fn try_write(&self, pcm: &[i16]) -> Result<(bool, UacPlaybackState)> {
-        let channels = self.playback.inner.config.channels as usize;
-        if pcm.is_empty() || !pcm.len().is_multiple_of(channels) {
-            return Err(AppError::BadRequest(
-                "UAC PCM must contain complete stereo frames".to_string(),
-            ));
-        }
         if self.playback.inner.stopped.load(Ordering::Acquire) {
             return Err(AppError::ServiceUnavailable(
                 "UAC playback has stopped".to_string(),
             ));
         }
 
-        let mut runtime = self.runtime.lock().unwrap();
-        if self.playback.inner.stopped.load(Ordering::Acquire) {
-            runtime.close();
-            return Err(AppError::ServiceUnavailable(
-                "UAC playback has stopped".to_string(),
-            ));
+        // Convert i16 samples to interleaved S16LE bytes for aplay stdin.
+        let mut bytes = Vec::with_capacity(pcm.len() * 2);
+        for sample in pcm {
+            bytes.extend_from_slice(&sample.to_le_bytes());
         }
-        let accepted = runtime.write(&self.playback.inner.config, pcm);
-        Ok((accepted, runtime.state()))
+
+        match self.tx.try_send(bytes) {
+            Ok(()) => Ok((true, self.state())),
+            Err(mpsc::error::TrySendError::Full(_)) => Ok((false, self.state())),
+            Err(mpsc::error::TrySendError::Closed(_)) => Ok((false, UacPlaybackState::Stalled)),
+        }
     }
 }
 
@@ -202,258 +185,160 @@ impl Drop for UacSession {
         let mut active = self.playback.inner.active_session.lock().unwrap();
         if active
             .as_ref()
-            .is_some_and(|session| Arc::ptr_eq(session, &self.runtime))
+            .is_some_and(|session| Arc::ptr_eq(session, &self.shared))
         {
             *active = None;
         }
-        drop(active);
-        self.runtime.lock().unwrap().close();
+        self.shared
+            .state
+            .store(UacPlaybackState::Idle.to_u8(), Ordering::Release);
     }
 }
 
-fn drive_sink(
-    sink: SessionSink,
-    config: &UacPlaybackConfig,
-    samples: &[i16],
-) -> (SessionSink, bool) {
-    match sink {
-        SessionSink::Closed { retry_at } => {
-            if retry_at.is_some_and(|deadline| Instant::now() < deadline) {
-                return (SessionSink::Closed { retry_at }, false);
-            }
+fn spawn_aplay(config: &UacPlaybackConfig) -> Option<(Child, Box<dyn Write + Send>)> {
+    let mut cmd = Command::new("aplay");
+    cmd.arg("-D")
+        .arg(&config.device_name)
+        .arg("-f")
+        .arg("S16_LE")
+        .arg("-r")
+        .arg(config.sample_rate.to_string())
+        .arg("-c")
+        .arg(config.channels.to_string())
+        .arg("--buffer-size=32768")
+        .arg("--period-size=1024")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
 
-            match open_pcm(config).and_then(|pcm| {
-                prime_pcm_with_silence(&pcm, config.channels as usize)?;
-                Ok(pcm)
-            }) {
-                Ok(pcm) => drive_probe(pcm, false, config, samples),
-                Err(error) => {
-                    warn!("Failed to open UAC playback device; retrying later: {error}");
-                    (
-                        SessionSink::Closed {
-                            retry_at: Some(Instant::now() + RETRY_BACKOFF),
-                        },
-                        false,
-                    )
+    match cmd.spawn() {
+        Ok(mut child) => {
+            let stdin = child.stdin.take()?;
+            info!("UAC aplay spawned (pid={})", child.id());
+            Some((child, Box::new(stdin)))
+        }
+        Err(error) => {
+            warn!("Failed to spawn UAC aplay: {error}");
+            None
+        }
+    }
+}
+
+fn aplay_loop(
+    config: &UacPlaybackConfig,
+    rx: &mut mpsc::Receiver<Vec<u8>>,
+    state: &Arc<SessionShared>,
+) {
+    let mut aplay: Option<(Child, Box<dyn Write + Send>)> = None;
+    let mut last_write = Instant::now();
+    let mut was_idle = false;
+
+    loop {
+        // Poll for data with an idle-aware timeout so a stalled aplay
+        // gets closed instead of blocking the worker thread forever.
+        let need_timeout = aplay.is_some() && last_write.elapsed() >= IDLE_CLOSE_TIMEOUT;
+        let deadline = if need_timeout || aplay.is_none() {
+            Some(Instant::now() + Duration::from_millis(200))
+        } else {
+            None
+        };
+
+        let frame = loop {
+            match rx.try_recv() {
+                Ok(f) => break Some(f),
+                Err(mpsc::error::TryRecvError::Disconnected) => break None,
+                Err(mpsc::error::TryRecvError::Empty) => {}
+            }
+            if let Some(dl) = deadline {
+                if Instant::now() >= dl {
+                    break None;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        };
+
+        match frame {
+            Some(f) => {
+                last_write = Instant::now();
+
+                // Resuming after idle — force a fresh aplay to avoid
+                // reusing a process stuck in an underrun state.
+                if was_idle {
+                    if let Some((c, s)) = aplay.take() {
+                        kill_aplay(c, s);
+                    }
+                    was_idle = false;
+                }
+
+                // Ensure aplay is alive.
+                if aplay.is_none() {
+                    aplay = spawn_aplay(config);
+                }
+
+                if let Some((child, _stdin)) = aplay.as_mut() {
+                    match child.try_wait() {
+                        Ok(Some(status)) => {
+                            warn!("UAC aplay exited: {status}");
+                            aplay = spawn_aplay(config);
+                            if aplay.is_none() {
+                                continue;
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(error) => {
+                            warn!("UAC aplay wait error: {error}");
+                            aplay = None;
+                            continue;
+                        }
+                    }
+                }
+
+                if let Some((_child, stdin)) = aplay.as_mut() {
+                    match stdin.write_all(&f) {
+                        Ok(()) => {
+                            let _ = stdin.flush();
+                            state
+                                .state
+                                .store(UacPlaybackState::Active.to_u8(), Ordering::Release);
+                        }
+                        Err(error) => {
+                            warn!("UAC aplay write failed: {error}");
+                            if let Some((c, s)) = aplay.take() {
+                                kill_aplay(c, s);
+                            }
+                            state
+                                .state
+                                .store(UacPlaybackState::Stalled.to_u8(), Ordering::Release);
+                        }
+                    }
+                }
+            }
+            None => {
+                if let Some((c, s)) = aplay.take() {
+                    kill_aplay(c, s);
+                }
+                was_idle = true;
+                state
+                    .state
+                    .store(UacPlaybackState::Waiting.to_u8(), Ordering::Release);
+                if rx.is_closed() {
+                    break;
                 }
             }
         }
-        SessionSink::Probing { pcm, stalled } => drive_probe(pcm, stalled, config, samples),
-        SessionSink::Active { pcm, last_progress } => {
-            drive_active(pcm, last_progress, config, samples)
-        }
     }
+
+    // Cleanup.
+    if let Some((c, s)) = aplay.take() {
+        kill_aplay(c, s);
+    }
+    info!("UAC aplay thread stopped");
 }
 
-fn drive_probe(
-    pcm: PCM,
-    stalled: bool,
-    config: &UacPlaybackConfig,
-    samples: &[i16],
-) -> (SessionSink, bool) {
-    match sink_is_consuming(&pcm) {
-        Ok(false) => (SessionSink::Probing { pcm, stalled }, false),
-        Ok(true) => {
-            if let Err(error) = reset_pcm_buffer(&pcm) {
-                warn!("Failed to activate UAC playback; retrying later: {error}");
-                return retry_later();
-            }
-            info!("UAC target started consuming microphone audio");
-            drive_active(pcm, Instant::now(), config, samples)
-        }
-        Err(error) => {
-            warn!("Failed to probe UAC playback; retrying later: {error}");
-            retry_later()
-        }
-    }
-}
-
-fn drive_active(
-    pcm: PCM,
-    last_progress: Instant,
-    config: &UacPlaybackConfig,
-    samples: &[i16],
-) -> (SessionSink, bool) {
-    match write_pcm_nonblocking(&pcm, samples, config.channels as usize) {
-        Ok(WriteOutcome::Progress) => (
-            SessionSink::Active {
-                pcm,
-                last_progress: Instant::now(),
-            },
-            true,
-        ),
-        Ok(WriteOutcome::Recovered) => (
-            SessionSink::Active {
-                pcm,
-                last_progress: Instant::now(),
-            },
-            false,
-        ),
-        Ok(WriteOutcome::Blocked) if last_progress.elapsed() < SINK_STALL_TIMEOUT => {
-            (SessionSink::Active { pcm, last_progress }, false)
-        }
-        Ok(WriteOutcome::Blocked) => {
-            if let Err(error) = reset_pcm_buffer(&pcm)
-                .and_then(|_| prime_pcm_with_silence(&pcm, config.channels as usize))
-            {
-                warn!("Failed to reset stalled UAC playback: {error}");
-                return retry_later();
-            }
-            info!("UAC target stopped consuming audio; waiting for playback activity");
-            (SessionSink::Probing { pcm, stalled: true }, false)
-        }
-        Err(error) => {
-            warn!("UAC playback write failed; retrying later: {error}");
-            retry_later()
-        }
-    }
-}
-
-fn retry_later() -> (SessionSink, bool) {
-    (
-        SessionSink::Closed {
-            retry_at: Some(Instant::now() + RETRY_BACKOFF),
-        },
-        false,
-    )
-}
-
-fn open_pcm(config: &UacPlaybackConfig) -> Result<PCM> {
-    let pcm = PCM::new(&config.device_name, Direction::Playback, true).map_err(|error| {
-        AppError::AudioError(format!(
-            "Failed to open UAC device {}: {error}",
-            config.device_name
-        ))
-    })?;
-    {
-        let params = HwParams::any(&pcm)
-            .map_err(|error| AppError::AudioError(format!("UAC HwParams failed: {error}")))?;
-        params
-            .set_channels(config.channels as u32)
-            .and_then(|_| params.set_rate(config.sample_rate, ValueOr::Nearest))
-            .and_then(|_| params.set_format(Format::s16()))
-            .and_then(|_| params.set_access(Access::RWInterleaved))
-            .and_then(|_| params.set_period_size_near(PERIOD_FRAMES, ValueOr::Nearest))
-            .and_then(|_| params.set_buffer_size_near(BUFFER_FRAMES))
-            .and_then(|_| pcm.hw_params(&params))
-            .map_err(|error| {
-                AppError::AudioError(format!("Failed to configure UAC playback: {error}"))
-            })?;
-    }
-
-    let (buffer_frames, period_frames) = pcm.get_params().map_err(|error| {
-        AppError::AudioError(format!("Failed to read UAC PCM parameters: {error}"))
-    })?;
-    {
-        let params = pcm.sw_params_current().map_err(|error| {
-            AppError::AudioError(format!("Failed to read UAC SwParams: {error}"))
-        })?;
-        let start_threshold =
-            (period_frames as Frames * START_THRESHOLD_PERIODS).min(buffer_frames as Frames);
-        params
-            .set_start_threshold(start_threshold)
-            .and_then(|_| params.set_avail_min(period_frames as Frames))
-            .and_then(|_| pcm.sw_params(&params))
-            .map_err(|error| {
-                AppError::AudioError(format!("Failed to configure UAC SwParams: {error}"))
-            })?;
-    }
-    pcm.prepare().map_err(|error| {
-        AppError::AudioError(format!("Failed to prepare UAC playback: {error}"))
-    })?;
-    info!(
-        "UAC playback opened on {} (buffer={} frames, period={} frames)",
-        config.device_name, buffer_frames, period_frames
-    );
-    Ok(pcm)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WriteOutcome {
-    Progress,
-    Blocked,
-    Recovered,
-}
-
-fn write_pcm_nonblocking(pcm: &PCM, samples: &[i16], channels: usize) -> Result<WriteOutcome> {
-    let total_frames = samples.len() / channels;
-    match pcm.avail() {
-        Ok(available) if available < total_frames as Frames => return Ok(WriteOutcome::Blocked),
-        Ok(_) => {}
-        Err(error) => {
-            recover_pcm(pcm, error)?;
-            return Ok(WriteOutcome::Recovered);
-        }
-    }
-
-    let io = pcm
-        .io_i16()
-        .map_err(|error| AppError::AudioError(format!("UAC PCM I/O failed: {error}")))?;
-    match io.writei(samples) {
-        Ok(0) => Ok(WriteOutcome::Blocked),
-        Ok(_) => Ok(WriteOutcome::Progress),
-        Err(error) if error.errno() == libc::EAGAIN => Ok(WriteOutcome::Blocked),
-        Err(error) => {
-            recover_pcm(pcm, error)?;
-            Ok(WriteOutcome::Recovered)
-        }
-    }
-}
-
-/// Once a full playback buffer gains at least one period of free space, the
-/// USB host has enabled the UAC streaming interface and is consuming samples.
-fn sink_is_consuming(pcm: &PCM) -> Result<bool> {
-    if pcm.state() == State::XRun {
-        return Ok(true);
-    }
-
-    match pcm.avail() {
-        Ok(available) => Ok(available >= PERIOD_FRAMES),
-        Err(error) if error.errno() == libc::EPIPE => Ok(true),
-        Err(error) => Err(AppError::AudioError(format!(
-            "Failed to query UAC playback availability: {error}"
-        ))),
-    }
-}
-
-fn recover_pcm(pcm: &PCM, error: alsa::Error) -> Result<()> {
-    let errno = error.errno();
-    pcm.try_recover(error, true).map_err(|recover_error| {
-        AppError::AudioError(format!("Failed to recover UAC playback: {recover_error}"))
-    })?;
-    if matches!(errno, libc::EPIPE | libc::ESTRPIPE) {
-        warn!("Recovered UAC playback after ALSA error {errno}");
-    }
-    Ok(())
-}
-
-fn reset_pcm_buffer(pcm: &PCM) -> Result<()> {
-    pcm.drop()
-        .and_then(|_| pcm.prepare())
-        .map_err(|error| AppError::AudioError(format!("Failed to reset UAC PCM: {error}")))
-}
-
-/// Prime the non-blocking ALSA buffer with silence. Subsequent WebSocket
-/// frames inspect buffer progress to detect when the USB host starts reading.
-fn prime_pcm_with_silence(pcm: &PCM, channels: usize) -> Result<()> {
-    let silence = vec![0i16; BUFFER_FRAMES as usize * channels];
-    let io = pcm
-        .io_i16()
-        .map_err(|error| AppError::AudioError(format!("UAC PCM I/O failed: {error}")))?;
-    let mut frame_offset = 0usize;
-    while frame_offset < BUFFER_FRAMES as usize {
-        match io.writei(&silence[frame_offset * channels..]) {
-            Ok(0) => break,
-            Ok(written) => frame_offset += written,
-            Err(error) if error.errno() == libc::EAGAIN => break,
-            Err(error) => {
-                return Err(AppError::AudioError(format!(
-                    "Failed to prime UAC PCM with silence: {error}"
-                )));
-            }
-        }
-    }
-    Ok(())
+fn kill_aplay(mut child: Child, stdin: Box<dyn Write + Send>) {
+    drop(stdin); // close pipe → EOF for aplay
+    let _ = child.wait();
 }
 
 #[cfg(test)]
@@ -484,26 +369,14 @@ mod tests {
     }
 
     #[test]
-    fn rejects_incomplete_stereo_frames_before_opening_alsa() {
-        let playback = UacPlayback::start(UacPlaybackConfig::default()).unwrap();
-        let session = playback.acquire_session().unwrap();
-
-        assert!(session.try_write(&[0]).is_err());
-        assert_eq!(session.state(), UacPlaybackState::Waiting);
-    }
-
-    #[test]
-    fn closed_sink_state_reflects_retry_backoff() {
-        assert_eq!(
-            SessionSink::Closed { retry_at: None }.state(),
-            UacPlaybackState::Waiting
-        );
-        assert_eq!(
-            SessionSink::Closed {
-                retry_at: Some(Instant::now())
-            }
-            .state(),
-            UacPlaybackState::Stalled
-        );
+    fn state_roundtrips_through_u8() {
+        for state in [
+            UacPlaybackState::Idle,
+            UacPlaybackState::Waiting,
+            UacPlaybackState::Active,
+            UacPlaybackState::Stalled,
+        ] {
+            assert_eq!(UacPlaybackState::from_u8(state.to_u8()), state);
+        }
     }
 }

--- a/src/otg/manager.rs
+++ b/src/otg/manager.rs
@@ -385,36 +385,25 @@ impl OtgGadgetManager {
             return Ok(());
         }
 
-        let entries = std::fs::read_dir(&functions_path).map_err(|e| {
-            AppError::Internal(format!(
-                "Failed to read functions directory {}: {}",
-                functions_path.display(),
-                e
-            ))
-        })?;
-
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            let name = match name.to_str() {
-                Some(n) => n,
-                None => continue,
-            };
-            if !name.contains(".usb") {
-                continue;
-            }
-
+        // Rebuild links in the same order functions were added
+        // (UAC first) so the isochronous endpoint gets a low-numbered
+        // hardware endpoint. `read_dir` returns entries in filesystem
+        // order (e.g. alphabetical), which pushes `uac1.usb0` after
+        // `hid.*` and assigns it a high endpoint number that DWC3
+        // cannot perform isochronous transfers on.
+        for func in &self.functions {
+            let name = func.name();
             let src = functions_path.join(name);
             let dest = self.config_path.join(name);
 
             if dest.exists() {
-                if let Err(e) = remove_file(&dest) {
-                    warn!(
+                remove_file(&dest).map_err(|e| {
+                    AppError::Internal(format!(
                         "Failed to remove existing config link {}: {}",
                         dest.display(),
                         e
-                    );
-                    continue;
-                }
+                    ))
+                })?;
             }
 
             create_symlink(&src, &dest)?;


### PR DESCRIPTION
### 问题

`5963dfa0`（完善 OTG UAC 音频支持）将 UAC 播放从 aplay 子进程重写为非阻塞 ALSA 状态机后，DWC3 复合设备上麦克风透传失效，UI 一直卡在「等待目标机」。

### 两个根本原因

**1. ConfigFS link 顺序被打乱 → 等时端点分配到 ep7**

`recreate_config_links()` 用 `std::fs::read_dir` 遍历 `functions/` 目录，按文件系统字母序重建 link。`uac1.usb0` 字母序排在 `hid.usb0~3` 之后，导致 UAC 等时端点被分配到 ep7。DWC3 无法在 ep7 上做等时传输，内核报错：

```
dwc3: request ... was not queued to ep7in
```

之前成功时 UAC 拿的是低编号端点（ep2），靠 UAC 优先 HID 创建保证。

**2. 非阻塞 ALSA 无法启动等时端点**

`playback.rs` 用 `PCM::new(..., true)`（非阻塞）+ `start_threshold` 自动启动，但 `snd_pcm_start` 返回 EPIPE：

```
Failed to start UAC PCM: snd_pcm_start failed with error 'Broken pipe (32)'
```

非阻塞模式在 DWC3 上无法激活等时端点。之前 aplay 子进程（阻塞 ALSA）可以。

### 修复

| 文件 | 改动 |
|------|------|
| `src/otg/manager.rs` | `recreate_config_links` 按 `functions` Vec 顺序（UAC 优先）重建 link |
| `src/audio/uac/playback.rs` | 改回 aplay 子进程方案（阻塞 ALSA），保留 `UacPlaybackState` 状态机接口和前端 UI |

同时复现之前 PR #285 的修复：
- 空闲恢复时强制新 aplay（was_idle 标志）
- `--buffer-size=32768` 大缓冲容错
- 5s 空闲超时
- try_recv 轮询（避免 blocking_recv 卡死线程）
